### PR TITLE
fix VampirePlayer is null when player is not alive

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,6 +69,9 @@ repositories {
      maven {
         url "https://www.cursemaven.com"
     }
+    maven {
+        url "https://maven.maxanier.de"
+    }
 
 }
 
@@ -77,7 +80,7 @@ dependencies {
     
 	compile fg.deobf("curse.maven:elenaidodge2-442962:3214812")
 	
-    compileOnly fg.deobf("curse.maven:vampirism-become-a-vampire:2902558")
+    compileOnly fg.deobf("de.teamlapen.vampirism:Vampirism:1.16.5-1.8.1:api")
 
 
 }


### PR DESCRIPTION
When the player is not alive all capabilities are not present, that means that https://github.com/Tfarcenim/ClassicBar/blob/6aa4e279796159d01d8974290bcb67f2d56b9a10/src/main/java/tfar/classicbar/overlays/mod/Blood.java#L41 always throw an exception when that is the case.

This can be prevented by either checking for `PlayerEntity#isAlive` or by calling `VampirePlayer#getOpt`.

I choose the ladder because there may be other reasons why `VampirePlayer#get` is not present.

Addidionally i switch from the full Vampirism jar to Vampirism Api, as everything can be done only with the Api

fixes TeamLapen/Vampirism#985