### PR TITLE
cancel Vampirism's blood bar rendering by sending an imc message

### DIFF
--- a/src/main/java/tfar/classicbar/ClassicBar.java
+++ b/src/main/java/tfar/classicbar/ClassicBar.java
@@ -25,6 +25,7 @@ public class ClassicBar {
     if(FMLEnvironment.dist.isClient()) {
       FMLJavaModLoadingContext.get().getModEventBus().addListener(this::postInit);
       FMLJavaModLoadingContext.get().getModEventBus().addListener(EventHandler::setupOverlays);
+      FMLJavaModLoadingContext.get().getModEventBus().addListener(EventHandler::sendModMessage);
     }
   }
 

--- a/src/main/java/tfar/classicbar/EventHandler.java
+++ b/src/main/java/tfar/classicbar/EventHandler.java
@@ -11,7 +11,9 @@ import net.minecraftforge.client.gui.overlay.IGuiOverlay;
 import net.minecraftforge.client.gui.overlay.NamedGuiOverlay;
 import net.minecraftforge.client.gui.overlay.VanillaGuiOverlay;
 import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.fml.InterModComms;
 import net.minecraftforge.fml.ModList;
+import net.minecraftforge.fml.event.lifecycle.InterModEnqueueEvent;
 import tfar.classicbar.compat.Helpers;
 import tfar.classicbar.config.ClassicBarsConfig;
 import tfar.classicbar.config.ConfigCache;
@@ -67,6 +69,10 @@ public class EventHandler implements IGuiOverlay {
     ClassicBarsConfig.leftorder.get().stream().filter(s -> registry.get(s) != null).forEach(e -> all.add(registry.get(e).setSide(false)));
     ClassicBarsConfig.rightorder.get().stream().filter(s -> registry.get(s) != null).forEach(e -> all.add(registry.get(e).setSide(true)));
     ConfigCache.bake();
+  }
+
+  public static void sendModMessage(InterModEnqueueEvent e) {
+    InterModComms.sendTo("vampirism", "disable-blood-bar", () -> true);
   }
 
   public static void setupOverlays(RegisterGuiOverlaysEvent e) {


### PR DESCRIPTION
While currently classic bar's blood bar is rendered correctly vampirism's blood bar will no be removed.

With Vampirism for 1.19 Vampirism is using Forges `IGuiOverlay` system thus no longer rely on the `RenderGameOverlayEvent` to render the blood bar.

Vampirisms blood bar can be either canceled by sending an IMC message or by canceling the `RenderGuiOverlayEvent.Pre` event.

This implementation uses the IMC message system. Otherwise you can use the `de.teamlapen.vampirism.api.client.VIngameOverlays.BLOOD_BAR_ID` to cancel the overlay event.