### PR TITLE
[1.20.1] Bug fix: Clients can not join remote servers without the mod.

### DIFF
--- a/src/main/java/tfar/classicbar/network/Message.java
+++ b/src/main/java/tfar/classicbar/network/Message.java
@@ -26,8 +26,8 @@ public final class Message {
     channel = NetworkRegistry.newSimpleChannel(
             new ResourceLocation(ClassicBar.MODID, channelName),
             () -> NETWORK_VERSION,
-            serverVersion -> NetworkRegistry.ABSENT.equals(serverVersion) || NETWORK_VERSION.equals(serverVersion),
-            clientVersion -> NetworkRegistry.ABSENT.equals(clientVersion) || NETWORK_VERSION.equals(clientVersion)
+            serverVersion -> NetworkRegistry.ABSENT.version().equals(serverVersion) || NETWORK_VERSION.equals(serverVersion),
+            clientVersion -> NetworkRegistry.ABSENT.version().equals(clientVersion) || NETWORK_VERSION.equals(clientVersion)
     );
     channel.registerMessage(id++, MessageExhaustionSync.class,
             MessageExhaustionSync::encode,


### PR DESCRIPTION
Since 1.20, forge has updated their API, causing servers without the mod will reject clients’ connection.
![1708083712_660522_ipZF](https://github.com/Tfarcenim/ClassicBar/assets/46566045/f4de502b-ac95-4cf7-8117-163515b2b3c1)